### PR TITLE
Run dlv from a temporary directory

### DIFF
--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -395,8 +395,8 @@ function! go#debug#StartWith(...) abort
     " current dir. We pass --wd= so the binary is still run from the current
     " dir.
     let original_dir = getcwd()
-    let tmp = fnamemodify(tempname(), ':h')
     let pkgname = go#package#FromPath(bufname(''))
+    let tmp = go#util#tempdir('vim-go-debug-')
     exe 'lcd ' . tmp
 
     echohl SpecialKey | echomsg 'Starting GoDebug...' | echohl None

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -299,4 +299,36 @@ function! go#util#GetLines()
   return buf
 endfunction
 
+" Make a named temporary directory which starts with "prefix".
+"
+" Unfortunately Vim's tempname() is not portable enough across various systems;
+" see: https://github.com/mattn/vim-go/pull/3#discussion_r138084911
+function! go#util#tempdir(prefix) abort
+  " See :help tempfile
+  if go#util#IsWin()
+    let l:dirs = [$TMP, $TEMP, 'c:\tmp', 'c:\temp']
+  else
+    let l:dirs = [$TMPDIR, '/tmp', './', $HOME]
+  endif
+
+  let l:dir = ''
+  for l:d in dirs
+    if !empty(l:d) && filewritable(l:d) == 2
+      let l:dir = l:d
+      break
+    endif
+  endfor
+
+  if l:dir == ''
+    echoerr 'Unable to find directory to store temporary directory in'
+    return
+  endif
+
+  " Not great randomness, but "good enough" for our purpose here.
+  let l:rnd = sha256(printf('%s%s', localtime(), fnamemodify(bufname(''), ":p")))
+  let l:tmp = printf("%s/%s%s", l:dir, a:prefix, l:rnd)
+  call mkdir(l:tmp, 'p', 0700)
+  return l:tmp
+endfunction
+
 " vim: sw=2 ts=2 et


### PR DESCRIPTION
This fixes two things:

- My comments here:
  https://github.com/fatih/vim-go/pull/1390/commits/8d617ece1e74bddfe47b5d0bc06dd1f821b54fcf#r138018608

  It's true that `:lcd` is only for the current window, but me
  personally I still wouldn't expect any user-visible changes in the
  current directory when using `:GoDebugStart`.

- It prevents `dlv` from creating a binary in the directory. At best
  this is an annoying side-effect, but at worst it could cause people to
  lose files: consider what would happen if someone has a package named
  `foo` but also had a file named `foo` in that directory?
  If you always use `go install` (like I do) then this is fine, and
  `:GoDebugStart` creating this file can be rather surprising.

Note: this PR requires this patch to work correctly:
https://github.com/fatih/vim-go/pull/1435