### PR TITLE
Documentation for debugger mode (WIP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ This plugin adds Go language support for Vim, with the following main features:
 
 * Build with `:GoBuild`, install with `:GoInstall` or test
   with `:GoTest` (run single tests via `:GoTestFunc`)
-* Show test coverage with `:GoCoverage` or in browser with `:GoCoverageBrowser` 
+* Debug programs with integrated [`delve`](https://github.com/derekparker/delve)
+  support with `:GoDebugStart`.
+* Show test coverage with `:GoCoverage` or in browser with `:GoCoverageBrowser`
 * Goto definition with `:GoDef`
 * Quick jump to declarations with `:GoDecls` or `:GoDeclsDir`
 * Show documentation with `:GoDoc` inside or in browser with `:GoDocBrowser`

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -29,6 +29,7 @@ function! s:exit(job, status) abort
   if has_key(s:state, 'job')
     call remove(s:state, 'job')
   endif
+  call s:clearState()
   if a:status != 0
     echohl Error | echo join(s:state['message'], "\n") . "\n" | echohl None
 	call getchar()
@@ -161,7 +162,6 @@ function! s:show_variables() abort
 endfunction
 
 function! s:clearState() abort
-  let s:state['breakpoint'] = {}
   let s:state['currentThread'] = {}
   let s:state['localVars'] = {}
   let s:state['functionArgs'] = {}
@@ -508,7 +508,9 @@ function! s:stack_cb(ch, json) abort
   let s:stack_name = ''
   let res = json_decode(a:json)
   if type(res) == v:t_dict && has_key(res, 'error') && !empty(res.error)
-    echohl Error | res.error | echohl None
+    echohl Error | echomsg res.error | echohl None
+    call s:clearState()
+    call go#debug#Restart()
     return
   endif
   if empty(res) || !has_key(res, 'result')

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -15,7 +15,7 @@ endif
 
 let s:addr = '127.0.0.1:8181'
 
-function! s:groutineID()
+function! s:groutineID() abort
   return s:state['currentThread'].goroutineID
 endfunction
 
@@ -29,7 +29,7 @@ function! s:exit(job, status) abort
   endif
 endfunction
 
-function! s:logger(prefix, ch, msg)
+function! s:logger(prefix, ch, msg) abort
   let winnum = bufwinnr(bufnr('__GODEBUG_OUTPUT__'))
   if winnum == -1
     return
@@ -189,7 +189,7 @@ function! go#debug#Stop() abort
   set balloonexpr=
 endfunction
 
-function! s:goto_file()
+function! s:goto_file() abort
   let m = matchlist(getline('.'), ' - \(.*\):\([0-9]\+\)$')
   if m[1] == ''
     return
@@ -209,19 +209,20 @@ function! s:goto_file()
   silent! normal! zvzz
 endfunction
 
-function! s:expand_var()
+function! s:expand_var() abort
   let name = matchstr(getline('.'), '^[^:]\+\ze: \.\.\.$')
   if name == ''
     return
   endif
   setlocal modifiable
+  let l = line('.')
   silent! %g/^\s/d _
-  call append('.', split(s:eval(name), "\n"))
-  silent! d _
+  call append(l, split(s:eval(name), "\n")[1:])
+  silent! exe 'norm!' l.'G'
   setlocal nomodifiable
 endfunction
 
-function! s:start_cb(ch, json)
+function! s:start_cb(ch, json) abort
   let res = json_decode(a:json)
   if type(res) == v:t_dict && has_key(res, 'error') && !empty(res.error)
     throw res.error
@@ -306,7 +307,7 @@ function! s:start_cb(ch, json)
   exe bufwinnr(oldbuf) 'wincmd w'
 endfunction
 
-function! s:starting(ch, msg)
+function! s:starting(ch, msg) abort
   echomsg a:msg
   let s:state['message'] += [a:msg]
   if stridx(a:msg, s:addr) != -1
@@ -339,7 +340,7 @@ function! go#debug#Start() abort
   endtry
 endfunction
 
-function! s:eval_tree(var, nest)
+function! s:eval_tree(var, nest) abort
   if a:var.name =~ '^\~'
     return ''
   endif
@@ -393,7 +394,7 @@ function! go#debug#Command(...) abort
   endtry
 endfunction
 
-function! s:update_variables()
+function! s:update_variables() abort
   let vars = [
   \{
   \  'method': 'RPCServer.ListLocalVars',
@@ -428,7 +429,7 @@ function! go#debug#Set(symbol, value) abort
   call s:update_variables()
 endfunction
 
-function! s:update_stacktrace()
+function! s:update_stacktrace() abort
   try
     let res = s:call_jsonrpc('RPCServer.Stacktrace', {'id': s:groutineID(), 'depth': 5})
     call s:show_stacktrace(res)

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -160,9 +160,15 @@ function! s:show_variables() abort
   wincmd p
 endfunction
 
-function! s:stop() abort
+function! s:clearState() abort
   let s:state['breakpoint'] = {}
   let s:state['currentThread'] = {}
+  let s:state['localVars'] = {}
+  let s:state['functionArgs'] = {}
+endfunction
+
+function! s:stop() abort
+  call s:clearState()
   if has_key(s:state, 'job')
     call job_stop(s:state['job'], 'kill')
     call remove(s:state, 'job')
@@ -540,6 +546,7 @@ endfunction
 
 function! go#debug#Restart() abort
   try
+    call s:clearState()
     let res = s:call_jsonrpc('RPCServer.Restart')
   catch
     echohl Error | echomsg v:exception | echohl None

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -376,6 +376,11 @@ function! s:starting(ch, msg) abort
 endfunction
 
 function! go#debug#StartWith(...) abort
+  if !go#util#has_job()
+    echoerr "This feature requires Vim 8.0.0087 or newer with +job."
+    return
+  endif
+
   if has_key(s:state, 'job') && job_status(s:state['job']) == 'run'
     return
   endif

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -552,8 +552,8 @@ sign define godebugbreakpoint text=> texthl=GoDebugBreakpoint
 sign define godebugcurline text== linehl=GoDebugCurrent texthl=GoDebugCurrent
 
 fun! s:hi()
-  hi GoDebugBreakpoint term=standout ctermbg=8 guibg=#BAD4F5
-  hi GoDebugCurrent term=reverse ctermbg=12 guibg=DarkBlue
+  hi GoDebugBreakpoint term=standout ctermbg=8  ctermfg=0 guibg=#BAD4F5  guifg=Black
+  hi GoDebugCurrent    term=reverse  ctermbg=12 ctermfg=7 guibg=DarkBlue guifg=White
 endfun
 augroup vim-go-breakpoint
   autocmd!

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -33,7 +33,7 @@ endfunction
 function! s:call_jsonrpc(method, ...) abort
   let s:state['rpcid'] += 1
   let json = json_encode({
-  \  'id': 1,
+  \  'id': s:state['rpcid'],
   \  'method': a:method,
   \  'params': a:000,
   \})

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -165,6 +165,7 @@ function! s:clearState() abort
   let s:state['currentThread'] = {}
   let s:state['localVars'] = {}
   let s:state['functionArgs'] = {}
+  silent! sign unplace 9999
 endfunction
 
 function! s:stop() abort

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -396,9 +396,9 @@ function! s:eval_tree(var, nest) abort
   let nest = a:nest
   let v = ''
   if !empty(a:var.name)
-    if len(a:var.children) > 0 && a:var.value == ''
+    if a:var.kind == 25
       let v .= repeat(' ', nest) . printf("%s: {...}\n", a:var.name)
-    elseif a:var.type != 'string' && a:var.len > 0 && a:var.value == ''
+    elseif a:var.kind ==  23
       let v .= repeat(' ', nest) . printf("%s: [%d]\n", a:var.name, a:var.len)
     else
       let v .= repeat(' ', nest) . printf("%s: %s\n", a:var.name, a:var.type == 'string' ? json_encode(a:var.value) : a:var.value)

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -2,14 +2,18 @@ if !exists('s:state')
   let s:state = {
   \ 'rpcid': 1,
   \ 'breakpoint': {},
+  \ 'currentThread': {},
   \}
 endif
 
 function! s:exit(job, status) abort
-  call remove(s:state, 'job')
+  if has_key(s:state, 'job')
+    call remove(s:state, 'job')
+  endif
 endfunction
 
 function! s:err_cb(ch, msg) abort
+  redraw
   echomsg a:msg
 endfunction
 
@@ -23,10 +27,13 @@ function! s:start() abort
     sleep 1
   endif
   let res = s:call_jsonrpc('RPCServer.ListBreakpoints')
+  if empty(res) || !has_key(res, 'result')
+    return
+  endif
   for bt in res.result.Breakpoints
     let s:state['breakpoint'][bt.id] = bt
     if bt.id >= 0
-      exe "sign place ". bt.id ." line=" . bt.line . " name=godebugbreakpoint file=" . bt.file
+      exe 'sign place '. bt.id .' line=' . bt.line . ' name=godebugbreakpoint file=' . bt.file
     endif
   endfor
 endfunction
@@ -39,12 +46,13 @@ function! s:call_jsonrpc(method, ...) abort
   \  'params': a:000,
   \})
   try
-    if !has_key(s:state, 'ch')
+    if !has_key(s:state, 'ch') || ch_info(s:state['ch']).status == 'closed'
       let s:state['ch'] = ch_open('127.0.0.1:8181')
       call ch_setoptions(s:state['ch'], {'mode': 'raw'})
+      sleep 1
     endif
     call ch_sendraw(s:state['ch'], json)
-    let json = ch_readraw(s:state['ch'])
+    let json = ch_readraw(s:state['ch'], {'timeout': 20000})
     let obj = json_decode(json)
     if type(obj) == 4 && has_key(obj, 'error') && !empty(obj.error)
       throw obj.error
@@ -57,11 +65,12 @@ function! s:call_jsonrpc(method, ...) abort
 endfunction
 
 function! go#debug#Diag() abort
+  let g:go_debug_diag = s:state
   echo s:state
 endfunction
 
-function! s:state(res) abort
-  if a:res ==# v:none
+function! s:update(res) abort
+  if type(a:res) ==# v:t_none
     return
   endif
   let state = a:res.result.State
@@ -73,30 +82,141 @@ function! s:state(res) abort
   let oldfile = fnamemodify(expand('%'), ':p:gs!\\!/!')
   let s:state['currentThread'] = state.currentThread
   if oldfile != filename
-    exe "edit" filename
+    silent exe 'edit' filename
   endif
   silent! exe 'norm!' linenr.'G'
   silent! normal! zvzz
-  sign unplace 9999
-  exe "sign place 9999 line=" . linenr . " name=godebugcurline file=" . filename
+  silent! sign unplace 9999
+  silent! exe 'sign place 9999 line=' . linenr . ' name=godebugcurline file=' . filename
 endfunction
 
-function! go#debug#Connect() abort
-  if !has_key(s:state, 'job') || !has_key(s:state, 'ch')
-    try
-      call s:start()
-    catch
-      echohl Error | echomsg v:exception | echohl None
-    endtry
+function! s:stacktrace(res) abort
+  if !has_key(a:res, 'result')
+    return
   endif
+  let winnum = bufwinnr(bufnr('__GODEBUG__'))
+  if winnum != -1
+    exe winnum 'wincmd w'
+  endif
+  silent %delete _
+  for i in range(len(a:res.result.Locations))
+    let loc = a:res.result.Locations[i]
+    call setline(i+1, printf('%s - %s:%d', loc.function.name, fnamemodify(loc.file, ':t'), loc.line))
+  endfor
+  wincmd p
+endfunction
+
+function! s:stop() abort
+  let s:state['breakpoint'] = {}
+  let s:state['currentThread'] = {}
+  if has_key(s:state, 'ch')
+    call ch_close(s:state['ch'])
+    call remove(s:state, 'ch')
+  endif
+  if has_key(s:state, 'job')
+    call job_stop(s:state['job'], 'kill')
+    call remove(s:state, 'job')
+  endif
+endfunction
+
+function! go#debug#Stop() abort
+  sign unplace 9999
+  for k in keys(s:state['breakpoint'])
+    let bt = s:state['breakpoint'][k]
+    if bt.id >= 0
+      silent exe 'sign unplace ' . bt.id
+    endif
+  endfor
+  for k in filter(map(split(execute('command GoDebug'), "\n")[1:], 'matchstr(v:val,"^\\s*\\zs\\S\\+")'), 'v:val!="GoDebugStart"')
+    exe 'delcommand' k
+  endfor
+  for k in map(split(execute('map <Plug>(go-debug-'), "\n")[1:], 'matchstr(v:val,"^n\\s\\+\\zs\\S\\+")')
+    exe 'unmap' k
+  endfor
+
+  call s:stop()
+
+  wincmd p
+  silent! exe bufnr('__GODEBUG__') 'bwipeout!'
+endfunction
+
+function! go#debug#Start() abort
+  if has_key(s:state, 'job') && has_key(s:state, 'ch')
+    return
+  endif
+  try
+    call s:start()
+  catch
+    echohl Error | echomsg v:exception | echohl None
+    return
+  endtry
+
+  let winnum = bufwinnr(bufnr('__GODEBUG__'))
+  if winnum != -1
+    return
+  endif
+  silent leftabove 20vnew
+  silent file `='__GODEBUG__'`
+  setlocal buftype=nofile bufhidden=wipe nobuflisted noswapfile nowrap nonumber cursorline
+  setlocal filetype=godebug
+  setlocal ballooneval
+  set balloonexpr=go#debug#BalloonExpr()
+  set ballooneval
+
+  command! -nargs=0 GoDebugDiag call go#debug#Diag()
+  command! -nargs=0 GoDebugToggleBreakpoint call go#debug#ToggleBreakpoint()
+  command! -nargs=0 GoDebugContinue call go#debug#Stack('continue')
+  command! -nargs=0 GoDebugNext call go#debug#Stack('next')
+  command! -nargs=0 GoDebugStep call go#debug#Stack('step')
+  command! -nargs=0 GoDebugStepIn call go#debug#Stack('stepin')
+  command! -nargs=0 GoDebugStepOut call go#debug#Stack('stepout')
+  command! -nargs=0 GoDebugRestart call go#debug#Restart()
+  command! -nargs=0 GoDebugStacktrace call go#debug#Stacktrace()
+  command! -nargs=* GoDebugSet call go#debug#Set(<f-args>)
+  command! -nargs=1 GoDebugEval call go#debug#Eval(<q-args>)
+
+  nnoremap <silent> <Plug>(go-debug-diag) :<C-u>call go#debug#Diag()<CR>
+  nnoremap <silent> <Plug>(go-debug-toggle-breakpoint) :<C-u>call go#debug#ToggleBreakpoint()<CR>
+  nnoremap <silent> <Plug>(go-debug-next) :<C-u>call go#debug#Stack('next')<CR>
+  nnoremap <silent> <Plug>(go-debug-step) :<C-u>call go#debug#Stack('step')<CR>
+  nnoremap <silent> <Plug>(go-debug-stepin) :<C-u>call go#debug#Stack('stepin')<CR>
+  nnoremap <silent> <Plug>(go-debug-stepout) :<C-u>call go#debug#Stack('stepout')<CR>
+  nnoremap <silent> <Plug>(go-debug-continue) :<C-u>call go#debug#Stack('continue')<CR>
+  nnoremap <silent> <Plug>(go-debug-stop) :<C-u>call go#debug#Stop()<CR>
+  nnoremap <silent> <Plug>(go-debug-eval) :<C-u>call go#debug#Eval(expand('<cword>'))<CR>
+
+  nmap <F5> <Plug>(go-debug-continue)
+  nmap <F6> <Plug>(go-debug-eval)
+  nmap <F9> <Plug>(go-debug-toggle-breakpoint)
+  nmap <F10> <Plug>(go-debug-next)
+  nmap <F11> <Plug>(go-debug-step)
+  nmap <buffer> q <Plug>(go-debug-stop)
+
+  augroup GoDebugWindow
+    au!
+    au BufWipeout <buffer> call go#debug#Stop()
+  augroup END
+  wincmd p
+endfunction
+
+function! s:balloon(arg) abort
+  try
+    let res = s:call_jsonrpc('RPCServer.State')
+    let goroutineID = res.result.State.currentThread.goroutineID
+    let res = s:call_jsonrpc('RPCServer.Eval', {'expr': a:arg, 'scope':{'GoroutineID': goroutineID}})
+    return printf('%s: %s', a:arg, res.result.Variable.value)
+  catch
+  endtry
+  return ''
+endfunction
+
+function! go#debug#BalloonExpr() abort
+  return s:balloon(v:beval_text)
 endfunction
 
 function! go#debug#Eval(arg) abort
   try
-    let res = s:call_jsonrpc('RPCServer.State')
-    let goroutineID = res.result.State.currentThread.goroutineID
-    let res = s:call_jsonrpc('RPCServer.Eval', {"expr": a:arg, "scope":{"GoroutineID": goroutineID}})
-    echo res
+    echo s:balloon(a:arg)
   catch
     echohl Error | echomsg v:exception | echohl None
   endtry
@@ -106,7 +226,7 @@ function! go#debug#Set(symbol, value) abort
   try
     let res = s:call_jsonrpc('RPCServer.State')
     let goroutineID = res.result.State.currentThread.goroutineID
-    let res = s:call_jsonrpc('RPCServer.Set', {"symbol": a:symbol, "value": a:value, "scope":{"GoroutineID": goroutineID}})
+    let res = s:call_jsonrpc('RPCServer.Set', {'symbol': a:symbol, 'value': a:value, 'scope':{'GoroutineID': goroutineID}})
     echo res
   catch
     echohl Error | echomsg v:exception | echohl None
@@ -115,8 +235,14 @@ endfunction
 
 function! go#debug#Stack(name) abort
   try
-    let res = s:call_jsonrpc('RPCServer.Command', {"name": a:name})
-    call s:state(res)
+    let res = s:call_jsonrpc('RPCServer.Command', {'name': a:name})
+    call s:update(res)
+  catch
+    echohl Error | echomsg v:exception | echohl None
+  endtry
+  try
+    let res = s:call_jsonrpc('RPCServer.Stacktrace', {'id': s:state['currentThread'].goroutineID, 'depth': 5})
+    call s:stacktrace(res)
   catch
     echohl Error | echomsg v:exception | echohl None
   endtry
@@ -124,7 +250,7 @@ endfunction
 
 function! go#debug#Stacktrace() abort
   try
-    let res = s:call_jsonrpc('RPCServer.Stacktrace')
+    let res = s:call_jsonrpc('RPCServer.Stacktrace', {'id': s:state['currentThread'].goroutineID})
     echo res
   catch
     echohl Error | echomsg v:exception | echohl None
@@ -153,14 +279,13 @@ function! go#debug#ToggleBreakpoint() abort
     endfor
     if type(found) == 4
       call remove(s:state['breakpoint'], bt.id)
-      let res = s:call_jsonrpc('RPCServer.ClearBreakpoint', {"id": found.id})
-      exe "sign unplace ". found.id ." file=" . found.file
+      let res = s:call_jsonrpc('RPCServer.ClearBreakpoint', {'id': found.id})
+      exe 'sign unplace '. found.id .' file=' . found.file
     else
-      let res = s:call_jsonrpc('RPCServer.CreateBreakpoint', {"Breakpoint":{"file": filename, "line": linenr}})
+      let res = s:call_jsonrpc('RPCServer.CreateBreakpoint', {'Breakpoint':{'file': filename, 'line': linenr}})
       let bt = res.result.Breakpoint
       let s:state['breakpoint'][bt.id] = bt
-      exe "sign place ". bt.id ." line=" . bt.line . " name=godebugbreakpoint file=" . bt.file
-      "let res = s:call_jsonrpc('RPCServer.Checkpoint', {"Where": bt.addr})
+      exe 'sign place '. bt.id .' line=' . bt.line . ' name=godebugbreakpoint file=' . bt.file
     endif
   catch
     echohl Error | echomsg v:exception | echohl None

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -375,7 +375,7 @@ function! s:starting(ch, msg) abort
   endif
 endfunction
 
-function! go#debug#Start(...) abort
+function! go#debug#StartWith(...) abort
   if has_key(s:state, 'job') && job_status(s:state['job']) == 'run'
     return
   endif
@@ -389,7 +389,7 @@ function! go#debug#Start(...) abort
     echohl SpecialKey | echomsg 'Starting GoDebug...' | echohl None
     let s:state['message'] = []
     exe 'lcd' fnamemodify(bufname(''), ':p:h')
-    let job = job_start(dlv . ' debug --headless --api-version=2 --log --listen=' . g:go_debug_address . ' --accept-multiclient -- ' . join(a:000, ' '), {
+    let job = job_start(dlv . ' debug --headless --api-version=2 --log --listen=' . g:go_debug_address . ' --accept-multiclient ' . join(a:000, ' '), {
     \ 'out_cb': function('s:starting'),
     \ 'err_cb': function('s:starting'),
     \ 'exit_cb': function('s:exit'),
@@ -401,6 +401,10 @@ function! go#debug#Start(...) abort
     echohl Error | echomsg v:exception | echohl None
     return
   endtry
+endfunction
+
+function! go#debug#Start(...) abort
+  return go#debug#StartWith(['--'] + a:000)
 endfunction
 
 function! s:eval_tree(var, nest) abort

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -6,6 +6,10 @@ if !exists('g:go_debug_windows')
         \ }
 endif
 
+if !exists('g:go_debug_address')
+  let g:go_debug_address = '127.0.0.1:8181'
+endif
+
 if !exists('s:state')
   let s:state = {
   \ 'rpcid': 1,
@@ -16,8 +20,6 @@ if !exists('s:state')
   \ 'message': [],
   \}
 endif
-
-let s:addr = '127.0.0.1:8181'
 
 function! s:groutineID() abort
   return s:state['currentThread'].goroutineID
@@ -351,7 +353,7 @@ endfunction
 function! s:starting(ch, msg) abort
   echomsg a:msg
   let s:state['message'] += [a:msg]
-  if stridx(a:msg, s:addr) != -1
+  if stridx(a:msg, g:go_debug_address) != -1
     call ch_setoptions(a:ch, {
     \ 'out_cb': function('s:logger', ['OUT: ']),
     \ 'err_cb': function('s:logger', ['ERR: ']),
@@ -373,7 +375,7 @@ function! go#debug#Start(...) abort
   try
     echohl SpecialKey | echomsg 'Starting GoDebug...' | echohl None
     let s:state['message'] = []
-    let job = job_start(dlv . ' debug --headless --api-version=2 --log --listen=' . s:addr . ' --accept-multiclient -- ' . join(a:000, ' '), {
+    let job = job_start(dlv . ' debug --headless --api-version=2 --log --listen=' . g:go_debug_address . ' --accept-multiclient -- ' . join(a:000, ' '), {
     \ 'out_cb': function('s:starting'),
     \ 'err_cb': function('s:starting'),
     \ 'exit_cb': function('s:exit'),

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -404,8 +404,10 @@ function! s:eval_tree(var, nest) abort
   if !empty(a:var.name)
     if a:var.kind == 25
       let v .= repeat(' ', nest) . printf("%s: {...}\n", a:var.name)
-    elseif a:var.kind ==  23
+    elseif a:var.kind ==  23 || a:var.kind == 24
       let v .= repeat(' ', nest) . printf("%s: [%d]\n", a:var.name, a:var.len)
+    elseif a:var.kind == 7
+      let v .= repeat(' ', nest) . printf("%s: %s\n", a:var.name, json_encode(nr2char(a:var.value)))
     else
       let v .= repeat(' ', nest) . printf("%s: %s\n", a:var.name, a:var.type == 'string' ? json_encode(a:var.value) : a:var.value)
     endif

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -1,0 +1,157 @@
+if !exists('s:state')
+  let s:state = {
+  \ 'rpcid': 1,
+  \ 'breakpoint': {},
+  \}
+endif
+
+function! s:exit(job, status)
+  echo string(a:status)
+  call remove(s:state, 'job')
+endfunction
+
+function! s:err_cb(ch, msg)
+  echomsg string(msg)
+endfunction
+
+function! s:start()
+  if !has_key(s:state, 'job')
+    let job = job_start(['dlv', 'debug', '--headless', '--api-version=2', '--log', '--listen=127.0.0.1:8181', '--accept-multiclient'])
+    call job_setoptions(job, {'exit_cb': function('s:exit'), 'stoponexit': 'kill'})
+    let s:state['job'] = job
+    sleep 1
+  endif
+  let res = s:call_jsonrpc('RPCServer.ListBreakpoints')
+  for bt in res.result.Breakpoints
+    let s:state['breakpoint'][bt.id] = bt
+    if bt.id >= 0
+      exe "sign place ". bt.id ." line=" . bt.line . " name=godebugbreakpoint file=" . bt.file
+    endif
+  endfor
+endfunction
+
+function! s:call_jsonrpc(method, ...) abort
+  let s:state['rpcid'] += 1
+  let json = json_encode({
+  \  'id': 1,
+  \  'method': a:method,
+  \  'params': a:000,
+  \})
+  try
+    if !has_key(s:state, 'ch')
+      let s:state['ch'] = ch_open('127.0.0.1:8181')
+      call ch_setoptions(s:state['ch'], {'err_cb': function('s:err_cb'), 'mode': 'raw'})
+    endif
+    call ch_sendraw(s:state['ch'], json)
+    let json = ch_readraw(s:state['ch'])
+    let obj = json_decode(json)
+    if type(obj) == 4 && has_key(obj, 'error') && !empty(obj.error)
+      throw obj.error
+    endif
+    return obj
+  catch
+    call remove(s:state, 'ch')
+    throw v:exception
+  endtry
+endfunction
+
+function! go#debug#Diag()
+  echo s:state
+endfunction
+
+function! s:state(res)
+  let state = a:res.result.State
+  if !has_key(state, 'currentThread')
+    return
+  endif
+  let filename = state.currentThread.file
+  let linenr = state.currentThread.line
+  exe "edit" filename
+  exe 'norm!' linenr.'G'
+  sil! norm! zvzz
+endfunction
+
+function! go#debug#Connect()
+  if !has_key(s:state, 'job') || !has_key(s:state, 'ch')
+    call s:start()
+  endif
+endfunction
+
+function! go#debug#Eval(arg)
+  try
+    let res = s:call_jsonrpc('RPCServer.State')
+    let goroutineID = res.result.State.currentThread.goroutineID
+    let res = s:call_jsonrpc('RPCServer.Eval', {"expr": a:arg, "scope":{"GoroutineID": goroutineID}})
+    echo res
+  catch
+    echohl Error | echomsg v:exception | echohl None
+  endtry
+endfunction
+
+function! go#debug#Set(symbol, value)
+  try
+    let res = s:call_jsonrpc('RPCServer.State')
+    let goroutineID = res.result.State.currentThread.goroutineID
+    let res = s:call_jsonrpc('RPCServer.Set', {"symbol": a:symbol, "value": a:value, "scope":{"GoroutineID": goroutineID}})
+    echo res
+  catch
+    echohl Error | echomsg v:exception | echohl None
+  endtry
+endfunction
+
+function! go#debug#Stack(name)
+  try
+    let res = s:call_jsonrpc('RPCServer.Command', {"name": a:name})
+    call s:state(res)
+  catch
+    echohl Error | echomsg v:exception | echohl None
+  endtry
+endfunction
+
+function! go#debug#Stacktrace()
+  try
+    let res = s:call_jsonrpc('RPCServer.Stacktrace')
+    echo res
+  catch
+    echohl Error | echomsg v:exception | echohl None
+  endtry
+endfunction
+
+function! go#debug#Restart()
+  try
+    let res = s:call_jsonrpc('RPCServer.Restart')
+  catch
+    echohl Error | echomsg v:exception | echohl None
+  endtry
+endfunction
+
+function! go#debug#ToggleBreakpoint()
+  let filename = fnamemodify(expand('%'), ':p:gs!\\!/!')
+  let linenr = line('.')
+  try
+    let found = v:none
+    for k in keys(s:state.breakpoint)
+      let bt = s:state.breakpoint[k]
+      if bt.file == filename && bt.line == linenr
+        let found = bt
+        break
+      endif
+    endfor
+    if type(found) == 4
+      call remove(s:state['breakpoint'], bt.id)
+      let res = s:call_jsonrpc('RPCServer.ClearBreakpoint', {"id": found.id})
+      exe "sign unplace ". found.id ." file=" . found.file
+    else
+      let res = s:call_jsonrpc('RPCServer.CreateBreakpoint', {"Breakpoint":{"file": filename, "line": linenr}})
+      let bt = res.result.Breakpoint
+      let s:state['breakpoint'][bt.id] = bt
+      exe "sign place ". bt.id ." line=" . bt.line . " name=godebugbreakpoint file=" . bt.file
+      "let res = s:call_jsonrpc('RPCServer.Checkpoint', {"Where": bt.addr})
+    endif
+  catch
+    echohl Error | echomsg v:exception | echohl None
+  endtry
+endfunction
+
+sign define godebugbreakpoint text=> texthl=Search
+

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -316,18 +316,20 @@ function! go#debug#Set(symbol, value) abort
 endfunction
 
 function! go#debug#Stack(name) abort
+  let name = a:name
   if len(s:state['breakpoint']) == 0
     try
-      call s:call_jsonrpc('RPCServer.CreateBreakpoint', {'Breakpoint':{'name': 'main'}})
-      let res = s:call_jsonrpc('RPCServer.Command', {'name': 'continue'})
-      call s:update(res)
+      let res = s:call_jsonrpc('RPCServer.FindLocation', {'loc': 'main.main'})
+      let res = s:call_jsonrpc('RPCServer.CreateBreakpoint', {'Breakpoint':{'addr': res.result.Locations[0].pc}})
+      let bt = res.result.Breakpoint
+      let s:state['breakpoint'][bt.id] = bt
+      let name = 'continue'
     catch
       echohl Error | echomsg v:exception | echohl None
     endtry
-    return
   endif
   try
-    let res = s:call_jsonrpc('RPCServer.Command', {'name': a:name})
+    let res = s:call_jsonrpc('RPCServer.Command', {'name': name})
     call s:update(res)
   catch
     echohl Error | echomsg v:exception | echohl None

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -481,7 +481,8 @@ function! s:stack_cb(ch, json) abort
   let s:stack_name = ''
   let res = json_decode(a:json)
   if type(res) == v:t_dict && has_key(res, 'error') && !empty(res.error)
-    throw res.error
+    echohl Error | res.error | echohl None
+    return
   endif
   if empty(res) || !has_key(res, 'result')
     return

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -119,7 +119,7 @@ function! s:show_stacktrace(res) abort
   silent %delete _
   for i in range(len(a:res.result.Locations))
     let loc = a:res.result.Locations[i]
-    call setline(i+1, printf('%s - %s:%d', loc.function.name, fnamemodify(loc.file, ':p'), loc.line))
+    call setline(i+1, printf('%s - %s:%d', loc.function.name, fnamemodify(loc.file, ':.p'), loc.line))
   endfor
   setlocal nomodifiable
   wincmd p

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -235,24 +235,30 @@ endfunction
 function! s:expand_var() abort
   let name = matchstr(getline('.'), '^[^:]\+\ze: {\.\.\.}$')
   if name != ''
+    let op = getline(line('.')+1) !~ '^ '
     setlocal modifiable
     let l = line('.')
     call s:delete_expands()
-    call append(l, split(s:eval(name), "\n")[1:])
+    if op
+      call append(l, split(s:eval(name), "\n")[1:])
+    endif
     silent! exe 'norm!' l.'G'
     setlocal nomodifiable
     return
   endif
   let m = matchlist(getline('.'), '^\([^:]\+\)\ze: \[\([0-9]\+\)\]$')
   if len(m) > 0 && m[1] != ''
+    let op = getline(line('.')+1) !~ '^ '
     setlocal modifiable
     let l = line('.')
     call s:delete_expands()
-    let vs = ''
-    for i in range(0, min([10, m[2]-1]))
-      let vs .= ' ' . s:eval(m[1] . '[' . i . ']')
-    endfor
-    call append(l, split(vs, "\n"))
+    if op
+      let vs = ''
+      for i in range(0, min([10, m[2]-1]))
+        let vs .= ' ' . s:eval(m[1] . '[' . i . ']')
+      endfor
+      call append(l, split(vs, "\n"))
+    endif
     silent! exe 'norm!' l.'G'
     setlocal nomodifiable
     return

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -398,7 +398,7 @@ function! s:eval_tree(var, nest) abort
   if !empty(a:var.name)
     if len(a:var.children) > 0 && a:var.value == ''
       let v .= repeat(' ', nest) . printf("%s: {...}\n", a:var.name)
-    elseif  a:var.len > 0 && a:var.value == ''
+    elseif a:var.type != 'string' && a:var.len > 0 && a:var.value == ''
       let v .= repeat(' ', nest) . printf("%s: [%d]\n", a:var.name, a:var.len)
     else
       let v .= repeat(' ', nest) . printf("%s: %s\n", a:var.name, a:var.type == 'string' ? json_encode(a:var.value) : a:var.value)

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -404,7 +404,7 @@ function! go#debug#StartWith(...) abort
 endfunction
 
 function! go#debug#Start(...) abort
-  return go#debug#StartWith(['--'] + a:000)
+  return call('go#debug#StartWith', ['--'] + a:000)
 endfunction
 
 function! s:eval_tree(var, nest) abort

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -556,3 +556,5 @@ hi GoDebugBreakpoint term=standout ctermbg=8 guibg=#BAD4F5
 hi GoDebugCurrent term=reverse ctermbg=12 guibg=DarkBlue
 sign define godebugbreakpoint text=> texthl=GoDebugBreakpoint
 sign define godebugcurline text== linehl=GoDebugCurrent texthl=GoDebugCurrent
+
+" vim: sw=2 ts=2 et

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -354,10 +354,16 @@ function! go#debug#Start(...) abort
   if has_key(s:state, 'job') && job_status(s:state['job']) == 'run'
     return
   endif
+
+  let dlv = go#path#CheckBinPath("dlv")
+  if empty(dlv)
+    return
+  endif
+
   try
     echohl SpecialKey | echomsg 'Starting GoDebug...' | echohl None
     let s:state['message'] = []
-    let job = job_start('dlv debug --headless --api-version=2 --log --listen=' . s:addr . ' --accept-multiclient -- ' . join(a:000, ' '), {
+    let job = job_start(dlv . ' debug --headless --api-version=2 --log --listen=' . s:addr . ' --accept-multiclient -- ' . join(a:000, ' '), {
     \ 'out_cb': function('s:starting'),
     \ 'err_cb': function('s:starting'),
     \ 'exit_cb': function('s:exit'),

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -1,3 +1,11 @@
+if !exists('g:go_debug_windows')
+  let g:go_debug_windows = {
+        \ 'stack': 'leftabove 20vnew',
+        \ 'out':   'botright 10new',
+        \ 'vars':  'leftabove 30vnew',
+        \ }
+endif
+
 if !exists('s:state')
   let s:state = {
   \ 'rpcid': 1,
@@ -272,26 +280,32 @@ function! s:start_cb(ch, json) abort
     return
   endif
 
-  silent leftabove 20vnew
-  silent file `='__GODEBUG_STACKTRACE__'`
-  setlocal buftype=nofile bufhidden=wipe nomodified nobuflisted noswapfile nowrap nonumber nocursorline
-  setlocal filetype=godebugstacktrace
-  nmap <buffer> <cr> :<c-u>call <SID>goto_file()<cr>
-  nmap <buffer> q <Plug>(go-debug-stop)
+  if exists('g:go_debug_windows["stack"]') && g:go_debug_windows['stack'] != ''
+    exe 'silent ' . g:go_debug_windows['stack']
+    silent file `='__GODEBUG_STACKTRACE__'`
+    setlocal buftype=nofile bufhidden=wipe nomodified nobuflisted noswapfile nowrap nonumber nocursorline
+    setlocal filetype=godebugstacktrace
+    nmap <buffer> <cr> :<c-u>call <SID>goto_file()<cr>
+    nmap <buffer> q <Plug>(go-debug-stop)
+  endif
 
-  silent botright 10new
-  silent file `='__GODEBUG_OUTPUT__'`
-  setlocal buftype=nofile bufhidden=wipe nomodified nobuflisted noswapfile nowrap nonumber nocursorline
-  setlocal filetype=godebugoutput
-  nmap <buffer> q <Plug>(go-debug-stop)
+  if exists('g:go_debug_windows["out"]') && g:go_debug_windows['out'] != ''
+    exe 'silent ' . g:go_debug_windows['out']
+    silent file `='__GODEBUG_OUTPUT__'`
+    setlocal buftype=nofile bufhidden=wipe nomodified nobuflisted noswapfile nowrap nonumber nocursorline
+    setlocal filetype=godebugoutput
+    nmap <buffer> q <Plug>(go-debug-stop)
+  endif
 
-  silent leftabove 30vnew
-  silent file `='__GODEBUG_VARIABLES__'`
-  setlocal buftype=nofile bufhidden=wipe nomodified nobuflisted noswapfile nowrap nonumber nocursorline
-  setlocal filetype=godebugvariables
-  call append(0, ["# Local Variables", "", "# Function Arguments"])
-  nmap <buffer> <cr> :<c-u>call <SID>expand_var()<cr>
-  nmap <buffer> q <Plug>(go-debug-stop)
+  if exists('g:go_debug_windows["vars"]') && g:go_debug_windows['vars'] != ''
+    exe 'silent ' . g:go_debug_windows['vars']
+    silent file `='__GODEBUG_VARIABLES__'`
+    setlocal buftype=nofile bufhidden=wipe nomodified nobuflisted noswapfile nowrap nonumber nocursorline
+    setlocal filetype=godebugvariables
+    call append(0, ["# Local Variables", "", "# Function Arguments"])
+    nmap <buffer> <cr> :<c-u>call <SID>expand_var()<cr>
+    nmap <buffer> q <Plug>(go-debug-stop)
+  endif
 
   command! -nargs=0 GoDebugDiag call go#debug#Diag()
   command! -nargs=0 GoDebugToggleBreakpoint call go#debug#ToggleBreakpoint()

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -5,19 +5,20 @@ if !exists('s:state')
   \}
 endif
 
-function! s:exit(job, status)
-  echo string(a:status)
+function! s:exit(job, status) abort
   call remove(s:state, 'job')
 endfunction
 
-function! s:err_cb(ch, msg)
-  echomsg string(msg)
+function! s:err_cb(ch, msg) abort
+  echomsg a:msg
 endfunction
 
-function! s:start()
+function! s:start() abort
   if !has_key(s:state, 'job')
     let job = job_start(['dlv', 'debug', '--headless', '--api-version=2', '--log', '--listen=127.0.0.1:8181', '--accept-multiclient'])
     call job_setoptions(job, {'exit_cb': function('s:exit'), 'stoponexit': 'kill'})
+    let ch = job_getchannel(job)
+    call ch_setoptions(job, {'err_cb': function('s:err_cb')})
     let s:state['job'] = job
     sleep 1
   endif
@@ -40,7 +41,7 @@ function! s:call_jsonrpc(method, ...) abort
   try
     if !has_key(s:state, 'ch')
       let s:state['ch'] = ch_open('127.0.0.1:8181')
-      call ch_setoptions(s:state['ch'], {'err_cb': function('s:err_cb'), 'mode': 'raw'})
+      call ch_setoptions(s:state['ch'], {'mode': 'raw'})
     endif
     call ch_sendraw(s:state['ch'], json)
     let json = ch_readraw(s:state['ch'])
@@ -51,33 +52,46 @@ function! s:call_jsonrpc(method, ...) abort
     return obj
   catch
     call remove(s:state, 'ch')
-    throw v:exception
+    throw substitute(v:exception, '^Vim', '', '')
   endtry
 endfunction
 
-function! go#debug#Diag()
+function! go#debug#Diag() abort
   echo s:state
 endfunction
 
-function! s:state(res)
+function! s:state(res) abort
+  if a:res ==# v:none
+    return
+  endif
   let state = a:res.result.State
   if !has_key(state, 'currentThread')
     return
   endif
   let filename = state.currentThread.file
   let linenr = state.currentThread.line
-  exe "edit" filename
-  exe 'norm!' linenr.'G'
-  sil! norm! zvzz
+  let oldfile = fnamemodify(expand('%'), ':p:gs!\\!/!')
+  let s:state['currentThread'] = state.currentThread
+  if oldfile != filename
+    exe "edit" filename
+  endif
+  silent! exe 'norm!' linenr.'G'
+  silent! normal! zvzz
+  sign unplace 9999
+  exe "sign place 9999 line=" . linenr . " name=godebugcurline file=" . filename
 endfunction
 
-function! go#debug#Connect()
+function! go#debug#Connect() abort
   if !has_key(s:state, 'job') || !has_key(s:state, 'ch')
-    call s:start()
+    try
+      call s:start()
+    catch
+      echohl Error | echomsg v:exception | echohl None
+    endtry
   endif
 endfunction
 
-function! go#debug#Eval(arg)
+function! go#debug#Eval(arg) abort
   try
     let res = s:call_jsonrpc('RPCServer.State')
     let goroutineID = res.result.State.currentThread.goroutineID
@@ -88,7 +102,7 @@ function! go#debug#Eval(arg)
   endtry
 endfunction
 
-function! go#debug#Set(symbol, value)
+function! go#debug#Set(symbol, value) abort
   try
     let res = s:call_jsonrpc('RPCServer.State')
     let goroutineID = res.result.State.currentThread.goroutineID
@@ -99,7 +113,7 @@ function! go#debug#Set(symbol, value)
   endtry
 endfunction
 
-function! go#debug#Stack(name)
+function! go#debug#Stack(name) abort
   try
     let res = s:call_jsonrpc('RPCServer.Command', {"name": a:name})
     call s:state(res)
@@ -108,7 +122,7 @@ function! go#debug#Stack(name)
   endtry
 endfunction
 
-function! go#debug#Stacktrace()
+function! go#debug#Stacktrace() abort
   try
     let res = s:call_jsonrpc('RPCServer.Stacktrace')
     echo res
@@ -117,7 +131,7 @@ function! go#debug#Stacktrace()
   endtry
 endfunction
 
-function! go#debug#Restart()
+function! go#debug#Restart() abort
   try
     let res = s:call_jsonrpc('RPCServer.Restart')
   catch
@@ -125,7 +139,7 @@ function! go#debug#Restart()
   endtry
 endfunction
 
-function! go#debug#ToggleBreakpoint()
+function! go#debug#ToggleBreakpoint() abort
   let filename = fnamemodify(expand('%'), ':p:gs!\\!/!')
   let linenr = line('.')
   try
@@ -154,4 +168,5 @@ function! go#debug#ToggleBreakpoint()
 endfunction
 
 sign define godebugbreakpoint text=> texthl=Search
+sign define godebugcurline text== texthl=DiffText
 

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -203,6 +203,7 @@ function! s:expand_var()
     return
   endif
   setlocal modifiable
+  silent! %g/^\s/d _
   call append('.', split(s:eval(name), "\n"))
   silent! d _
   setlocal nomodifiable
@@ -234,20 +235,20 @@ function! s:start_cb(ch, json)
   silent leftabove 20vnew
   silent file `='__GODEBUG_STACKTRACE__'`
   setlocal buftype=nofile bufhidden=wipe nomodified nobuflisted noswapfile nowrap nonumber nocursorline
-  setlocal filetype=godebug-stacktrace
+  setlocal filetype=godebugstacktrace
   nmap <buffer> <cr> :<c-u>call <SID>goto_file()<cr>
   nmap <buffer> q <Plug>(go-debug-stop)
 
   silent botright 10new
   silent file `='__GODEBUG_OUTPUT__'`
   setlocal buftype=nofile bufhidden=wipe nomodified nobuflisted noswapfile nowrap nonumber nocursorline
-  setlocal filetype=godebug-output
+  setlocal filetype=godebugoutput
   nmap <buffer> q <Plug>(go-debug-stop)
 
   silent leftabove 30vnew
   silent file `='__GODEBUG_VARIABLES__'`
   setlocal buftype=nofile bufhidden=wipe nomodified nobuflisted noswapfile nowrap nonumber nocursorline
-  setlocal filetype=godebug-variables
+  setlocal filetype=godebugvariables
   nmap <buffer> <cr> :<c-u>call <SID>expand_var()<cr>
   nmap <buffer> q <Plug>(go-debug-stop)
 

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -1,7 +1,3 @@
-if !executable('dlv')
-  finish
-endif
-
 if !exists('s:state')
   let s:state = {
   \ 'rpcid': 1,

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -548,9 +548,17 @@ function! go#debug#ToggleBreakpoint() abort
   endtry
 endfunction
 
-hi GoDebugBreakpoint term=standout ctermbg=8 guibg=#BAD4F5
-hi GoDebugCurrent term=reverse ctermbg=12 guibg=DarkBlue
 sign define godebugbreakpoint text=> texthl=GoDebugBreakpoint
 sign define godebugcurline text== linehl=GoDebugCurrent texthl=GoDebugCurrent
+
+fun! s:hi()
+  hi GoDebugBreakpoint term=standout ctermbg=8 guibg=#BAD4F5
+  hi GoDebugCurrent term=reverse ctermbg=12 guibg=DarkBlue
+endfun
+augroup vim-go-breakpoint
+  autocmd!
+  autocmd ColorScheme * call s:hi()
+augroup end
+call s:hi()
 
 " vim: sw=2 ts=2 et

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -381,6 +381,7 @@ function! go#debug#Start(...) abort
   try
     echohl SpecialKey | echomsg 'Starting GoDebug...' | echohl None
     let s:state['message'] = []
+    exe 'lcd' fnamemodify(bufname(''), ':p:h')
     let job = job_start(dlv . ' debug --headless --api-version=2 --log --listen=' . g:go_debug_address . ' --accept-multiclient -- ' . join(a:000, ' '), {
     \ 'out_cb': function('s:starting'),
     \ 'err_cb': function('s:starting'),

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -292,6 +292,7 @@ function! go#debug#ToggleBreakpoint() abort
   endtry
 endfunction
 
-sign define godebugbreakpoint text=> texthl=Search
-sign define godebugcurline text== texthl=DiffText
-
+hi GoDebugBreakpoint term=standout ctermbg=8 guibg=#BAD4F5
+hi GoDebugCurrent term=reverse ctermbg=12 guibg=DarkBlue
+sign define godebugbreakpoint text=> texthl=GoDebugBreakpoint
+sign define godebugcurline text== linehl=GoDebugCurrent texthl=GoDebugCurrent

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -765,6 +765,42 @@ CTRL-t
         Surname: "Smith",
       }
 <
+
+                                                               *:GoDebugStart*
+:GoDebugStart
+
+    Start Go Debugger. This debugger similar to Visual Studio or Eclipse which
+    has following features:
+
+    * Show stacktrace and Jump
+    * List local variables
+    * List function arguments
+    * Expand values of struct or array/slice
+    * Show balloon on the symbol
+    * Show output of stdout/stderr
+    * Toggle breakpoint
+    * Stack operation continue/next/stepin/stepout
+
+    To start debugger, type `:GoDebugStart`. If you want to pass arguments to
+    the program, append arguments following this command: >
+
+        :GoDebugStart -age 18
+<
+    This may take few seconds. After while compiling your code, You'll see 3
+    panes windows. The stacktrace in left side, left bottom in variable list,
+    command output in bottom.
+
+    You should add breakpoint at the first. Go to somewhere where you want to
+    break on debugger. Then type <F9> to toggle breakpoint.  To start command,
+    type <F5>.
+
+    If your program reach the breakpoint immediately, go debugger stop with
+    the breakpoint. Then, you can go next line <F10> or step in <F11>.
+    When the program stop in the debugger, stacktrace and variable list will
+    be updated with the current value.
+    Struct value is displayed as '{...}', Array/Slice is displayed like '[4]'.
+    To expand the values, type <CR> on the variable name.
+
 ==============================================================================
 MAPPINGS                                                        *go-mappings*
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -21,10 +21,11 @@ CONTENTS                                                         *go-contents*
   5. Text Objects.................................|go-text-objects|
   6. Functions....................................|go-functions|
   7. Settings.....................................|go-settings|
-  8. FAQ/Troubleshooting..........................|go-troubleshooting|
-  9. Development..................................|go-development|
- 10. Donation.....................................|go-donation|
- 11. Credits......................................|go-credits|
+  8. Debugger.....................................|go-debug|
+  9. FAQ/Troubleshooting..........................|go-troubleshooting|
+ 10. Development..................................|go-development|
+ 11. Donation.....................................|go-donation|
+ 12. Credits......................................|go-credits|
 
 ==============================================================================
 INTRO                                                               *go-intro*
@@ -38,6 +39,7 @@ easily.
 
   * Improved Syntax highlighting with items such as Functions, Operators,
     Methods.
+  * Debug programs with integrated `delve` support with |:GoDebugStart|.
   * Auto completion support via `gocode`.
   * Better `gofmt` on save, which keeps cursor position and doesn't break your
     undo history.
@@ -765,42 +767,7 @@ CTRL-t
         Name: "John",
         Surname: "Smith",
       }
-<
 
-                                                               *:GoDebugStart*
-:GoDebugStart
-
-    Start Go Debugger. This debugger similar to Visual Studio or Eclipse which
-    has following features:
-
-    * Show stacktrace and Jump
-    * List local variables
-    * List function arguments
-    * Expand values of struct or array/slice
-    * Show balloon on the symbol
-    * Show output of stdout/stderr
-    * Toggle breakpoint
-    * Stack operation continue/next/stepin/stepout
-
-    To start debugger, type `:GoDebugStart`. If you want to pass arguments to
-    the program, append arguments following this command: >
-
-        :GoDebugStart -age 18
-<
-    This may take few seconds. After while compiling your code, You'll see 3
-    panes windows. The stacktrace in left side, left bottom in variable list,
-    command output in bottom.
-
-    You should add breakpoint at the first. Go to somewhere where you want to
-    break on debugger. Then type <F9> to toggle breakpoint.  To start command,
-    type <F5>.
-
-    If your program reach the breakpoint immediately, go debugger stop with
-    the breakpoint. Then, you can go next line <F10> or step in <F11>.
-    When the program stop in the debugger, stacktrace and variable list will
-    be updated with the current value.
-    Struct value is displayed as '{...}', Array/Slice is displayed like '[4]'.
-    To expand the values, type <CR> on the variable name.
 
 ==============================================================================
 MAPPINGS                                                        *go-mappings*
@@ -1672,29 +1639,236 @@ Disable everything (same as not setting 'foldmethod' to `syntax`):
 <
 
 ==============================================================================
-DEVELOPMENT                                               *go-development*
+DEBUGGER                                                            *go-debug*
 
-vim-go supports test files written in VimL. Please check `autoload` folder for
-examples. If you add a new feature be sure you also include the `_test.vim`
-file next to the script. Test functions should be starting with `Test_`,
-example:
->
- function Test_run_fmt()
-   call assert_equal(expected, actual)
-   ...
- endfunction
-<
-You can locally test it by running:
->
- make
-<
-This will run all tests and print either `PASS` or `FAIL` to indicate the
-final status of all tests. Additionally, each new pull request will trigger a
-new Travis-ci job.
+Vim-go comes with a special "debugger mode". This starts a `delve` process in
+the background and provides various commands to communicate with it.
 
+This debugger is similar to Visual Studio or Eclipse and has the following
+features:
+
+  * Show stack trace and jumps.
+  * List local variables.
+  * List function arguments.
+  * Expand values of struct or array/slice.
+  * Show balloon on the symbol.
+  * Show output of stdout/stderr.
+  * Toggle breakpoint.
+  * Stack operation continue/next/step in/step out.
+
+This feature requires Vim 8.0.0087 or newer with the |+job| feature. Neovim
+does _not_ work (yet).
+
+                                                              *go-debug-intro*
+GETTING STARTED WITH THE DEBUGGER~
+
+Use |:GoDebugStart| to start the debugger. Any arguments will be passed on to
+the program; for example:
+>
+    :GoDebugStart -age 18
+<
+This may take few seconds. After compiling your code, You'll see trhee new
+windows: the stack trace on left side, the variable list on the bottom-left,
+and command output at the bottom.
+
+You can now add breakpoints with |:GoDebugToggleBreakpoint| (<F9>) and run
+your program with |:GoDebugContinue| (<F5>).
+
+The program will halt on the breakpoint, at which point you can inspect the
+program state. You can go to the next line with |:GoDebugNext| (<F10>) or step
+in with |:GoDebugStep| (<F11>).
+
+Struct values are displayed as `{...}`, array/slices as `[4]`. Use <CR> on the
+variable name to expand the values.
+
+Once you're done use |:GoDebugStop| to close the debugging windows and halt
+the `dlv` process, or |:GoDebugRestart| to reset everything and start anew.
+
+                                                           *go-debug-commands*
+DEBUGGER COMMANDS~
+
+Only |:GoDebugStart| and |:GoDebugStartWith| are available by default; the
+rest of the commands become available after starting debug mode.
+
+                                           *:GoDebugStart* *:GoDebugStartWith*
+:GoDebugStart [program-args]
+:GoDebugStartWith [dlv-args]
+
+    Start the debug mode; this does several things:
+
+      * Start `dlv debug` on the package the current buffer belongs to.
+      * Setup the debug windows according to |'g:go_debug_windows'|.
+      * Make the `:GoDebug*` command and `(go-debug-*)` mappings available.
+
+  `:GoDebugStart` will pass any arguments to the Go program, whereas
+  `GoDebugStartWith` will pass any arguments to `dlv`. `:GoDebugStart arg` is
+  equivalent to `:GoDebugStart -- arg`; it's just a convenience shortcut.
+
+  Use |:GoDebugStop| to stop `dlv` and exit debugging mode.
+
+  TODO: maybe "delcommand" this when debug mode is started?
+  TODO: Be clearer about compile errors; just a brief flash now.
+
+                                                             *:GoDebugRestart*
+:GoDebugRestart
+
+    Stop the program (if running) and restart `dlv` which will recompiling the
+    package.
+    The current window layout and breakpoints will be left intact.
+
+    TODO: This is not how this command currently works!
+
+                                                                *:GoDebugStop*
+                                                             *(go-debug-stop)*
+:GoDebugStop
+
+    Stop `dlv` and remove all debug-specific commands, mappings, and windows.
+    
+    TODO: GoDebugStop and GoDebugStart doesn't work very well; get loads of
+    strange errors. 
+
+
+
+                                                    *:GoDebugToggleBreakpoint*
+                                                *(go-debug-toggle-breakpoint)*
+:GoDebugToggleBreakpoint
+
+    Toggle breakpoint for the current line. A line with a breakpoint will have
+    the {godebugbreakpoint} |:sign| placed on it. The line the program is
+    currently halted on will have the {godebugcurline} sign.
+
+                                    *hl-GoDebugCurrent* *hl-GoDebugBreakpoint*
+    A line with a breakpoint will be highlighted with the {GoDebugBreakpoint}
+    group; the line the program is currently halted on will be highlighted
+    with {hl-GoDebugCurrent}.
+
+    Mapped to <F9> by default.
+
+                                                            *:GoDebugContinue*
+                                                         *(go-debug-continue)*
+:GoDebugContinue
+
+    Continue execution until breakpoint or program termination. It will start
+    the program if it hasn't been started yet.
+
+    Mapped to <F5> by default.
+
+                                                                *:GoDebugNext*
+                                                             *(go-debug-next)*
+:GoDebugNext
+
+    Step over to next source line.
+
+    Advance execution by one line. If the program is stopped it will start the
+    program and halt on the first line.
+
+    TODO: If program hasn't started it will error out (but only if there is a
+    breakpoint, it will work if there are no breakpoints).
+
+    Mapped to <F10> by default.
+
+                                                                *:GoDebugStep*
+                                                             *(go-debug-step)*
+:GoDebugStep
+
+    Single step through program.
+
+    Mapped to <F11> by default.
+
+                                                              *:GoDebugStepIn*
+                                                           *(go-debug-stepin)*
+:GoDebugStepIn
+
+    TODO
+    TODO
+
+                                                             *:GoDebugStepOut*
+                                                          *(go-debug-stepout)*
+
+
+:GoDebugStepOut
+
+    TODO
+    TODO
+
+                                                                 *:GoDebugSet*
+:GoDebugSet {var} {value}
+
+    Set the variable {var} to {value}.
+
+    Setting an int value: >
+      :GoDebugSet truth 42
+<
+
+    TODO: can not set variables of type string (not implemented)
+    TODO: Document more?
+
+                                                                *:GoDebugEval*
+                                                             *(go-debug-eval)*
+:GoDebugEval {expr}
+
+    Evaluate a Go expression.
+>
+    :GoDebugEval truth == 42
+    truth == 42 true 
+<
+    Mapped to <F6> by default, which will evaluate the current line.
+    
+    TODO: Document what _exactly_ you can and can't do with this.
+
+                                                             *:GoDebugCommand*
+:GoDebugCommand [command]
+
+    Send a direct command to `dlv` with the `RPCServer.Command` RPC command.
+
+    TODO: Document why this is useful.
+
+                                                                *:GoDebugDiag*
+                                                             *(go-debug-diag)*
+:GoDebugDiag
+
+    Show the current state of the debugger. Useful for development, bug
+    reports, etc.
+
+
+                                                           *go-debug-settings*
+DEBUGGER SETTINGS~
+
+                                                        *'g:go_debug_windows'*
+
+Controls the window layout for debugging mode. This is a |dict| with three
+possible keys: "stack", "out", and "vars"; the windows will created in that
+order with the commands in the value.
+A window will not be created if a key is missing or empty.
+
+Defaults:
+>
+  let g:go_debug_windows = {
+        \ 'stack': 'leftabove 20vnew',
+        \ 'out':   'botright 10new',
+        \ 'vars':  'leftabove 30vnew',
+  \ }
+<
+Show only variables on the right-hand side: >
+
+  let g:go_debug_windows = {
+        \ 'vars':  'rightbelow 60vnew',
+  \ }
+<
+
+TODO: Should probably allow re-creating a window later on. Also useful if you
+close one.
+
+                                                        *'g:go_debug_address'*
+
+Server address `dlv` will listen on; must be in `hostname:port` format.
+Defaults to `127.0.0.1:8181`:
+>
+  let g:go_debug_address = '127.0.0.1:8181'
+<
 
 ==============================================================================
-FAQ TROUBLESHOOTING                                     *go-troubleshooting*
+FAQ TROUBLESHOOTING                                       *go-troubleshooting*
 
 I get "not an editor command" error when I invoke :GoXXX~
 
@@ -1799,6 +1973,28 @@ By default new terminals are opened in a vertical split. To change it
 >
  let g:go_term_mode = "split"
 >
+
+==============================================================================
+DEVELOPMENT                                               *go-development*
+
+vim-go supports test files written in VimL. Please check `autoload` folder for
+examples. If you add a new feature be sure you also include the `_test.vim`
+file next to the script. Test functions should be starting with `Test_`,
+example:
+>
+ function Test_run_fmt()
+   call assert_equal(expected, actual)
+   ...
+ endfunction
+<
+You can locally test it by running:
+>
+ make
+<
+This will run all tests and print either `PASS` or `FAIL` to indicate the
+final status of all tests. Additionally, each new pull request will trigger a
+new Travis-ci job.
+
 
 ==============================================================================
 DONATION                                                         *go-donation*

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -107,6 +107,7 @@ command! -nargs=0 GoKeyify call go#keyify#Keyify()
 " -- debug
 if !exists(':GoDebugStart')
   command! -nargs=* GoDebugStart call go#debug#Start(<f-args>)
+  command! -nargs=* GoDebugStartWith call go#debug#StartWith(<f-args>)
 endif
 
 

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -104,4 +104,21 @@ command! -nargs=0 GoTemplateAutoCreateToggle call go#template#ToggleAutoCreate()
 " -- keyify
 command! -nargs=0 GoKeyify call go#keyify#Keyify()
 
+" -- debug
+if !exists(':GoDebugEval')
+  command! -nargs=0 GoDebugConnect call go#debug#Connect()
+  command! -nargs=0 GoDebugDiag call go#debug#Diag()
+  command! -nargs=0 GoDebugToggleBreakpoint call go#debug#ToggleBreakpoint()
+  command! -nargs=0 GoDebugContinue call go#debug#Stack('continue')
+  command! -nargs=0 GoDebugNext call go#debug#Stack('next')
+  command! -nargs=0 GoDebugStep call go#debug#Stack('step')
+  command! -nargs=0 GoDebugStepIn call go#debug#Stack('stepin')
+  command! -nargs=0 GoDebugStepOut call go#debug#Stack('stepout')
+  command! -nargs=0 GoDebugRestart call go#debug#Restart()
+  command! -nargs=0 GoDebugStacktrace call go#debug#Stacktrace()
+  command! -nargs=* GoDebugSet call go#debug#Set(<f-args>)
+  command! -nargs=1 GoDebugEval call go#debug#Eval(<q-args>)
+endif
+
+
 " vim: sw=2 ts=2 et

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -106,7 +106,7 @@ command! -nargs=0 GoKeyify call go#keyify#Keyify()
 
 " -- debug
 if !exists(':GoDebugStart')
-  command! -nargs=0 GoDebugStart call go#debug#Start()
+  command! -nargs=* GoDebugStart call go#debug#Start(<f-args>)
 endif
 
 

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -105,19 +105,8 @@ command! -nargs=0 GoTemplateAutoCreateToggle call go#template#ToggleAutoCreate()
 command! -nargs=0 GoKeyify call go#keyify#Keyify()
 
 " -- debug
-if !exists(':GoDebugEval')
-  command! -nargs=0 GoDebugConnect call go#debug#Connect()
-  command! -nargs=0 GoDebugDiag call go#debug#Diag()
-  command! -nargs=0 GoDebugToggleBreakpoint call go#debug#ToggleBreakpoint()
-  command! -nargs=0 GoDebugContinue call go#debug#Stack('continue')
-  command! -nargs=0 GoDebugNext call go#debug#Stack('next')
-  command! -nargs=0 GoDebugStep call go#debug#Stack('step')
-  command! -nargs=0 GoDebugStepIn call go#debug#Stack('stepin')
-  command! -nargs=0 GoDebugStepOut call go#debug#Stack('stepout')
-  command! -nargs=0 GoDebugRestart call go#debug#Restart()
-  command! -nargs=0 GoDebugStacktrace call go#debug#Stacktrace()
-  command! -nargs=* GoDebugSet call go#debug#Set(<f-args>)
-  command! -nargs=1 GoDebugEval call go#debug#Eval(<q-args>)
+if !exists(':GoDebugStart')
+  command! -nargs=0 GoDebugStart call go#debug#Start()
 endif
 
 

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -22,6 +22,7 @@ let s:packages = [
       \ "github.com/zmb3/gogetdoc",
       \ "github.com/josharian/impl",
       \ "github.com/dominikh/go-tools/cmd/keyify",
+      \ "github.com/derekparker/delve/cmd/dlv",
       \ ]
 
 " These commands are available on any filetypes

--- a/syntax/godebugoutput.vim
+++ b/syntax/godebugoutput.vim
@@ -1,0 +1,13 @@
+if exists("b:current_syntax")
+  finish
+endif
+
+syn match godebugOutputErr '^ERR:.*'
+syn match godebugOutputOut '^OUT:.*'
+
+let b:current_syntax = "godebugoutput"
+
+hi def link godebugOutputErr Comment
+hi def link godebugOutputOut Normal
+
+" vim: sw=2 ts=2 et

--- a/syntax/godebugstacktrace.vim
+++ b/syntax/godebugstacktrace.vim
@@ -1,0 +1,11 @@
+if exists("b:current_syntax")
+  finish
+endif
+
+syn match godebugStacktrace '^\S\+'
+
+let b:current_syntax = "godebugoutput"
+
+hi def link godebugStacktrace SpecialKey
+
+" vim: sw=2 ts=2 et

--- a/syntax/godebugvariables.vim
+++ b/syntax/godebugvariables.vim
@@ -2,10 +2,12 @@ if exists("b:current_syntax")
   finish
 endif
 
+syn match godebugTitle '^#.*'
 syn match godebugVariables '^\s*\S\+\ze:'
 
 let b:current_syntax = "godebugvariables"
 
+hi def link godebugTitle Underlined
 hi def link godebugVariables Question
 
 " vim: sw=2 ts=2 et

--- a/syntax/godebugvariables.vim
+++ b/syntax/godebugvariables.vim
@@ -1,0 +1,11 @@
+if exists("b:current_syntax")
+  finish
+endif
+
+syn match godebugVariables '^\s*\S\+\ze:'
+
+let b:current_syntax = "godebugvariables"
+
+hi def link godebugVariables Question
+
+" vim: sw=2 ts=2 et


### PR DESCRIPTION
This sets up the structure for the documentation for the new debug mode;
it's not 100% complete yet. I also added a bunch of TODOs There are a
bunch of TODOs sprinkled around for stuff I noticed that behaved
unexpected/buggy.

I added it as a new section instead of putting it in the regular
commands/etc. sections. This seemed to make the most sense to me
personally: this way there is an obvious location for a "getting
started" section, and we can keep the docs for :GoDebugStart as a short
and to the point reference doc.It also avoids having to add "This
command/mapping is only available after using :GoDebug" on all the
commands.

I can move stuff around if you want.